### PR TITLE
Fixed sscanf pattern by seeking to tab section.

### DIFF
--- a/src/splayTable.c
+++ b/src/splayTable.c
@@ -588,6 +588,7 @@ static void computeClearHSPs(TightString * array, FILE * seqFile, boolean second
 	Nucleotide nucleotide;
 	KmerOccurence * hit;
 	char line[MAXLINE];
+    char* start;
 	char c;
 	
 	Coordinate mapCount = 0;
@@ -614,7 +615,8 @@ static void computeClearHSPs(TightString * array, FILE * seqFile, boolean second
 #endif 
 			exit(1);
 		}
-		sscanf(line, "%*s\t%li\t", &long_var);
+        start = strchr(line, '\t');
+		sscanf(start, "\t%li\t", &long_var);
 		*seqID = (IDnum) long_var;
 		if (*seqID == 0)
 			abort();


### PR DESCRIPTION
The sscanf format "%*s\t%li\t" was failing to match the annotated
FastA header strings. This patch just seeks to the first tab and
uses "\t%li\t" as the format pattern.

This bug was triggered on OS X 10.6.7 when using a reference genome.
