### PR TITLE
isCreateBinary() should not be inline

### DIFF
--- a/src/readSet.c
+++ b/src/readSet.c
@@ -72,7 +72,7 @@ static Mask * newMask(SequencesWriter *seqWriteInfo, Coordinate position)
 // note that createBinary is only used by velveth
 //
 boolean createBinary = false;
-inline boolean isCreateBinary()
+boolean isCreateBinary()
 {
 	return createBinary;
 }

--- a/src/readSet.h
+++ b/src/readSet.h
@@ -61,7 +61,7 @@ void detachDubiousReads(ReadSet * reads, boolean * dubiousReads);
 
 void destroyReadSet(ReadSet * reads);
 
-inline boolean isCreateBinary();
+boolean isCreateBinary();
 void setCreateBinary(boolean val);
 
 #endif


### PR DESCRIPTION
This function is used from several .c files; with inline here,
compilation with clang was broken.
