### PR TITLE
FIx SCAFFOLD include gaurd

### DIFF
--- a/src/scaffold.h
+++ b/src/scaffold.h
@@ -18,7 +18,7 @@ Copyright 2007, 2008 Daniel Zerbino (zerbino@ebi.ac.uk)
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
-#ifndef _SSCAFFOLD_H_
+#ifndef _SCAFFOLD_H_
 #define _SCAFFOLD_H_
 
 typedef struct connection_st Connection;


### PR DESCRIPTION
Looks to be a typo on the ifndef/define for the scaffold header
